### PR TITLE
Alumni Visit Info on Teachers' Day

### DIFF
--- a/_our-school/School Crest & Song.md
+++ b/_our-school/School Crest & Song.md
@@ -36,7 +36,7 @@ proprietary.</p>
 <br>Our country - we cherish and adore
 <br>We all pledge to be strong and true.</p>
 <p><strong><em>Take courage friends for we are one</em></strong>
-<br><strong><em>Respect one another honour our elders</em></strong>
+<br><strong><em>Respect one another, care for you and me</em></strong>
 <br><strong><em>Diligent stead-fast in all that we do</em></strong>
 <br><strong><em>This is the path to a bright future.</em></strong>
 </p>

--- a/pages/Highlights.md
+++ b/pages/Highlights.md
@@ -6,8 +6,8 @@ variant: tiptap
 ---
 <h2><strong>Be Part of Teachers’ Day 2025 </strong>🍎</h2>
 <p>Teachers’ Day is a time to say <strong>THANK YOU</strong> to those who have
-guided, encouraged, and inspired us. As Pei Tong alumni, you have two special
-ways to join in the celebration this year:</p>
+guided, encouraged, and inspired us. If you are Pei Tong alumni, you have
+two special ways to join in the celebration this year:</p>
 <h3>1. Write a Note of Thanks ✍️</h3>
 <p>A few words from you can brighten a teacher’s day. Share your e-message
 at <strong><a href="https://go.gov.sg/saythanksptps" class="decorated-link" rel="noopener" target="_new">this link</a></strong> and

--- a/pages/Highlights.md
+++ b/pages/Highlights.md
@@ -4,6 +4,55 @@ permalink: /highlights/
 description: ""
 variant: tiptap
 ---
+<h2><strong>Be Part of Teachers’ Day 2025 🎉</strong></h2>
+<p>Teachers’ Day is a time to say <strong>THANK YOU</strong> to those who have
+guided, encouraged, and inspired us. As Pei Tong alumni, you have two special
+ways to join in the celebration this year:</p>
+<h3>1. Write a Note of Thanks ✨</h3>
+<p>A few words from you can brighten a teacher’s day. Share your message
+at <strong><a href="https://go.gov.sg/saythanksptps" class="decorated-link" rel="noopener" target="_new">this link</a></strong> and
+let your encouragement make this Teachers’ Day even more memorable!</p>
+<h3>2. Visit Your Teacher 💐</h3>
+<p>Want to say thank you in person? You can <strong>make an appointment*</strong> to
+visit your teachers on <strong>Thursday, 4 September 2025</strong>.</p>
+<blockquote>
+<p>Time: <strong>10.40 a.m. – 11.30 a.m.</strong>
+<br>Venue:<strong> School Foyer (outside the General Office)</strong>
+</p>
+</blockquote>
+<p>*<strong>IMPORTANT: </strong>Make an appointment <strong><u>BEFORE</u> </strong>coming
+as teachers may not be in school after dismissal time. To do so, you may
+email<strong> </strong>or text your teacher. Staff emails can be found <strong>here</strong>.</p>
+<h4><strong>Important reminders for alumni visitors:</strong></h4>
+<ol data-tight="true" class="tight">
+<li>
+<p>If you are currently studying in a secondary school, please come in your
+school uniform. Polytechnic/ITE/University students should be dressed smartly.</p>
+</li>
+<li>
+<p>Enter the school by Gate A only.</p>
+</li>
+<li>
+<p>Prove that you have an appointment with a teacher by showing your email
+or text message to the security guards at the gate. Visitors without proof
+of appointment will be turned away.</p>
+</li>
+<li>
+<p>If the teacher you are visiting is unwell/unavailable, you will not be
+able to enter the school.</p>
+</li>
+<li>
+<p>Meetings must take place at the school foyer only.</p>
+</li>
+<li>
+<p>All visitors MUST leave the school by 11.30 a.m.</p>
+</li>
+</ol>
+<h3>Celebrate Together ❤️</h3>
+<p>Whether you send a note or make a visit, your appreciation will make a
+difference. Let’s come together as the Pei Tong family to celebrate the
+teachers who have shaped our journey!</p>
+<hr>
 <h2>Photo Gallery</h2>
 <p>Check out&nbsp;<a href="https://www.peitongpri.moe.edu.sg/photos/" rel="noopener noreferrer nofollow" target="_blank">our Photo Gallery</a> for
 the latest photographs and catch a glimpse of school life at Pei Tong Primary

--- a/pages/Highlights.md
+++ b/pages/Highlights.md
@@ -4,12 +4,12 @@ permalink: /highlights/
 description: ""
 variant: tiptap
 ---
-<h2><strong>Be Part of Teachers’ Day 2025 🎉</strong></h2>
+<h2><strong>Be Part of Teachers’ Day 2025 </strong>🍎</h2>
 <p>Teachers’ Day is a time to say <strong>THANK YOU</strong> to those who have
 guided, encouraged, and inspired us. As Pei Tong alumni, you have two special
 ways to join in the celebration this year:</p>
-<h3>1. Write a Note of Thanks ✨</h3>
-<p>A few words from you can brighten a teacher’s day. Share your message
+<h3>1. Write a Note of Thanks ✍️</h3>
+<p>A few words from you can brighten a teacher’s day. Share your e-message
 at <strong><a href="https://go.gov.sg/saythanksptps" class="decorated-link" rel="noopener" target="_new">this link</a></strong> and
 let your encouragement make this Teachers’ Day even more memorable!</p>
 <h3>2. Visit Your Teacher 💐</h3>

--- a/pages/Highlights.md
+++ b/pages/Highlights.md
@@ -22,7 +22,7 @@ visit your teachers on <strong>Thursday, 4 September 2025</strong>.</p>
 </blockquote>
 <p>*<strong>IMPORTANT: </strong>Make an appointment <strong><u>BEFORE</u> </strong>coming
 as teachers may not be in school after dismissal time. To do so, you may
-email<strong> </strong>or text your teacher. Staff emails can be found <strong>here</strong>.</p>
+email<strong> </strong>or text your teacher.</p>
 <h4><strong>Important reminders for alumni visitors:</strong></h4>
 <ol data-tight="true" class="tight">
 <li>


### PR DESCRIPTION
Highlights page is updated with info for alumni who wish to be a part of Tr's day celebrations. For input and approval, please.

I noticed staff email is not available on the website. Instead, website has a guide for parents to access staff emails via PG. For alumni who have difficulty contacting the teacher they wish to visit, perhaps we can set up a link for them to leave their contact.